### PR TITLE
Fixing sitemap

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -11,7 +11,7 @@ linkedin: andrewvojak
 email: andrew.vojak@gmail.com
 
 url: https://avojak.com/blog
-# baseurl: /blog
+# baseurl: /
 
 authors:
   avojak:


### PR DESCRIPTION
Currently, your [sitemap](http://avojak.com/blog/sitemap) is completely wrong because of the wrong base URL.

Current:
```
<loc>
https://avojak.com/blog/blog/2018/07/29/i-am-not-a-writer/
</loc>
```

After the change:
```
<loc>
https://avojak.com/blog/2018/07/29/i-am-not-a-writer/
</loc>
```